### PR TITLE
Fix/use real nulls

### DIFF
--- a/generate.coffee
+++ b/generate.coffee
@@ -267,7 +267,8 @@ getCsvHeader = (object) ->
 convertToCsv = (object) ->
   csv = ''
   for key, value of object when not Array.isArray(value)
-    csv += "\"#{escapeQuotesForCsv(value)}\","
+    # Write null values as real nulls
+    csv += if value? then "\"#{escapeQuotesForCsv(value)}\"," else ","
   return csv.slice(0,-1)
 
 writeCsv = (file, csv) ->


### PR DESCRIPTION
Fixes this issue
https://github.com/RJMetrics/magenerator/issues/16

##### Functional tests
- Run `coffee generate.coffee` and make sure null coupon codes are in there as nulls and not "null"