### PR TITLE
added base_grand_total column

### DIFF
--- a/generate.coffee
+++ b/generate.coffee
@@ -107,6 +107,7 @@ generateOrders = (total, customers, addresses, products) ->
       entity_id: index
       items: items
       grand_total: grandTotal
+      base_grand_total: grandTotal
       customer_id: customer.entity_id
       status: getOrderStatus()
       customer_email: customer.email


### PR DESCRIPTION
This branch adds a base_grand_total column, which is what we should be using in the demo. I assume the other one still exists and it's ok to leave it in.

##### Functional tests
- Run `coffee generate.coffee` and make sure base_grand_total shows up now