### PR TITLE
added store_id to customer_flat_order_items table and customer_entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ CREATE TABLE `customer_entity` (
   `entity_id` int(10) unsigned NOT NULL AUTO_INCREMENT COMMENT 'Entity Id',
   `email` varchar(255) DEFAULT NULL COMMENT 'Email',
   `group_id` smallint(5) unsigned NOT NULL DEFAULT 0 COMMENT 'Group Id',
+  `store_id` smallint(5) unsigned DEFAULT NULL COMMENT 'Store Id',
   `created_at` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00' COMMENT 'Created At',
   `updated_at` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00' COMMENT 'Updated At',
   PRIMARY KEY (`entity_id`)
@@ -101,6 +102,7 @@ CREATE TABLE `sales_flat_order_item` (
 `sku` varchar(255) DEFAULT NULL COMMENT 'Sku',
 `product_type` varchar(255) DEFAULT NULL COMMENT 'Product Type',
 `product_id` int(10) unsigned DEFAULT NULL COMMENT 'Product Id',
+`store_id` smallint(5) unsigned DEFAULT NULL COMMENT 'Store Id',
 `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Created At',
 `updated_at` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00' COMMENT 'Updated At',
 PRIMARY KEY (`item_id`),

--- a/generate.coffee
+++ b/generate.coffee
@@ -161,7 +161,7 @@ getCustomerToBuyFavoringRepeats = (customers, orderCounts, orderCreatedAt) ->
     if cust.created_at > orderCreatedAt
       cust.created_at = orderCreatedAt #make sure customer created at or before first order placed
     return cust
-  return getCustomerToBuyFavoringRepeats(customers, orderCounts, null) #recursively try another customer
+  return getCustomerToBuyFavoringRepeats(customers, orderCounts) #recursively try another customer
 
 getRandomEmailDomain = () ->
   list = ['gmail', 'yahoo', 'magento', 'hotmail', 'aol']


### PR DESCRIPTION
This branch finishes off https://github.com/RJMetrics/magenerator/issues/39 by adding store_id to the `customer_entity` and `sales_flat_order_item` tables.

##### Functional tests
- `coffee generate.coffee`
- Make sure the store_id shows up in those tables
- Make sure the create table statement works and the store_id shows up in the right position (3rd from the end)