### PR TITLE
Add company table to magenerator for b2b

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,32 @@ PRIMARY KEY (`store_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Core Store';
 ```
 
+```
+CREATE TABLE `company` (
+  `entity_id` int(10) UNSIGNED NOT NULL COMMENT 'Company ID',
+  `status` smallint(5) UNSIGNED NOT NULL DEFAULT '0' COMMENT 'Status',
+  `company_name` varchar(40) DEFAULT NULL COMMENT 'Company Name',
+  `legal_name` varchar(80) DEFAULT NULL COMMENT 'Legal Name',
+  `company_email` varchar(255) DEFAULT NULL COMMENT 'Company Email',
+  `vat_tax_id` varchar(40) DEFAULT NULL COMMENT 'VAT Tax ID',
+  `reseller_id` varchar(40) DEFAULT NULL COMMENT 'Reseller ID',
+  `comment` text COMMENT 'Comment',
+  `street` varchar(40) DEFAULT NULL COMMENT 'Street',
+  `city` varchar(40) DEFAULT NULL COMMENT 'City',
+  `country_id` varchar(2) DEFAULT NULL COMMENT 'Country ID',
+  `region` varchar(40) DEFAULT NULL COMMENT 'Region',
+  `region_id` int(10) UNSIGNED DEFAULT NULL COMMENT 'Region Id',
+  `postcode` varchar(30) DEFAULT NULL COMMENT 'Postcode',
+  `telephone` varchar(20) DEFAULT NULL COMMENT 'Telephone',
+  `customer_group_id` int(10) UNSIGNED DEFAULT NULL COMMENT 'Customer Group ID',
+  `sales_representative_id` int(10) UNSIGNED DEFAULT NULL COMMENT 'Sales Representative ID',
+  `super_user_id` int(10) UNSIGNED DEFAULT NULL COMMENT 'Super User ID',
+  `reject_reason` text COMMENT 'Reject Reason',
+  `rejected_at` timestamp NULL DEFAULT NULL COMMENT 'Rejected At'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Company Table';
+```
+
+
 Finally, import all csv file into the mysql tables by running the following commands:
 
 ```
@@ -147,7 +173,7 @@ LOAD DATA INFILE 'core_store.csv' into table magento.core_store FIELDS TERMINATE
 LOAD DATA INFILE 'sales_flat_order.csv' into table magento.sales_flat_order FIELDS TERMINATED BY ',' ENCLOSED BY '"' LINES TERMINATED BY '\n' IGNORE 1 LINES;
 LOAD DATA INFILE 'sales_flat_order_item.csv' into table magento.sales_flat_order_item FIELDS TERMINATED BY ',' ENCLOSED BY '"' LINES TERMINATED BY '\n' IGNORE 1 LINES;
 LOAD DATA INFILE 'sales_flat_order_address.csv' into table magento.sales_flat_order_address FIELDS TERMINATED BY ',' ENCLOSED BY '"' LINES TERMINATED BY '\n' IGNORE 1 LINES;
-
+LOAD DATA INFILE 'company.csv' into table magento.company FIELDS TERMINATED BY ',' ENCLOSED BY '"' LINES TERMINATED BY '\n' IGNORE 1 LINES;
 ```
 
 If you need to load the data into a remote db from a local csv file, use this command

--- a/generate.coffee
+++ b/generate.coffee
@@ -363,16 +363,6 @@ generateCompany = (id) ->
 generateCompanySuffix = () ->
   chance.pickone([".com", ".com", ".com", "", "", " LLC", " Party Ltd.", " GmbH", ".biz", "Co", " Co", "Corp"])
 
-generateQuotes = (total, customer_id) ->
-  quotes = []
-  for index in [0..total]
-    quotes.push(generateQuote(index, customer_id))
-  return quote
-
-generateQuote = (id, customer_id) ->
-  id: id
-  customer_id: customer_id
-
 escapeQuotesForCsv = (str) ->
   if typeof str is 'string'
     str.replace('"','""')

--- a/generate.coffee
+++ b/generate.coffee
@@ -21,7 +21,7 @@ ORDER_ITEM_FILE = 'data/sales_flat_order_item.csv'
 ADDRESS_FILE = 'data/sales_flat_order_address.csv'
 PRODUCT_FILE = 'data/products.csv'
 STORES_FILE = 'data/core_store.csv'
-COMPANIES_FILE = 'data/companies.csv'
+COMPANIES_FILE = 'data/company.csv'
 CURRENCY = "$"
 STORE_NAME = "MageMart"
 COUPONS = chance.unique(chance.hash, 20, {casing: 'upper', length: 5})
@@ -337,8 +337,28 @@ generateCompanies = (total) ->
   return companies
 
 generateCompany = (id) ->
-  id: id
-  name: "#{capitalize(chance.word())}#{generateCompanySuffix()}"
+  name = "#{capitalize(chance.word())}#{generateCompanySuffix()}"
+  company =
+    entity_id: id
+    status: 0
+    company_name: name
+    legal_name: name
+    company_email: null
+    vat_tax_id: null
+    reseller_id: null
+    comment: null
+    street: null
+    city: null
+    country_id: null
+    region: null
+    region_id: null
+    postcode: null
+    telephone: null
+    customer_group_id: null
+    sales_representative_id: null
+    super_user_id: null
+    reject_reason: null
+    rejected_at: null
 
 generateCompanySuffix = () ->
   chance.pickone([".com", ".com", ".com", "", "", " LLC", " Party Ltd.", " GmbH", ".biz", "Co", " Co", "Corp"])


### PR DESCRIPTION
This branch adds company.csv to the generated data and documentation for creating the DB / loading it into mysql. There are some placeholder columns that I'm not generating data just for yet. I'm not sure exactly what is needed, but the schema matches Magento 2.2

##### Functional tests
- Run `coffee generate.coffee`
- Make sure company.csv ends up in the data directory